### PR TITLE
Correct documentation on bootloaders

### DIFF
--- a/byo_sample_code/circuit_python/README.md
+++ b/byo_sample_code/circuit_python/README.md
@@ -1,15 +1,15 @@
 # Setup
 
 1. [Install Mu Software](https://learn.adafruit.com/introducing-itsy-bitsy-m0/installing-mu-editor)
-2. Update Bootloader to version 6.3
+2. Update Bootloader to version 7.x
     - Plugin your device via USB to your computer. The storage drive will show up as an external USB disk.
     - Double tap RESET button to get to the bootloader, the device will un-mount the disk and re-mount as the bootloader ("ITSYBTSY") If device doesn't show up, try double tapping more slowly. 
-    - Download the lastest bootloader https://circuitpython.org/board/itsybitsy_m0_express/
+    - Download the lastest 7.x bootloader https://circuitpython.org/board/itsybitsy_m0_express/
     - Extract, copy the file with the UF2 extension to the ITSYBTSY drive that shows up on your PC. No need to rename file. Device will reboot immediately after copy.
     - The device will reboot and mount its storage disk. Probably called "NO_NAME" however you can rename it to whatever you please.
     - Open the `boot_out.txt` file. You should see updated firmware version and date.
 3. Update lib packages
-    - Download the latest 6.3.0 CircuitPython here: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20210611/adafruit-circuitpython-bundle-6.x-mpy-20210611.zip
+    - Download the latest 7.x CircuitPython here: [https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20220715/adafruit-circuitpython-bundle-7.x-mpy-20220715.zip](https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/20220715/adafruit-circuitpython-bundle-7.x-mpy-20220715.zip)
     - Extract and open the `lib/` folder, find and copy these files over to your device's `lib/` folder:
       - `adafruit_hid/` (folder)
       - `adafruit_dotstar.mpy`


### PR DESCRIPTION
## Problem
I struggled for many days to try and figure out why I couldn't get my 2.5 BYO keyboard working. 

## Cause
It turns out that I had the 7.x bootloader (which is the current listed version on the website) , whereas the readme.md in the documentation is hard coded to download the 6.x libraries

<img width="1315" alt="Screen Shot 2022-07-17 at 11 43 17 AM" src="https://user-images.githubusercontent.com/242382/179418102-040dd4de-1ff5-430b-baae-9f1f0817a6d4.png">

## Solution
For anyone else in this situation, there are 2 possible solutions

1. Use the older 6.x bootloader with the 6.x libraries
2. Use the newer 7.x bootloader with the 7.x libraries

Since the 6.x bootloader is harder to find (you have to [search the archives](https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin/itsybitsy_m0_express/)), I recommend people update to the 7.x libraries


https://circuitpython.org/board/itsybitsy_m0_express/


## Changes

This pull request updates the documentation to
- clarify that the bootloader and library version should match
- change the links to point to the 7.x libraries
